### PR TITLE
Show all unsafe files when aborting commit, not just the first one

### DIFF
--- a/safe-commit-hook.py
+++ b/safe-commit-hook.py
@@ -65,14 +65,18 @@ def read_patterns():
         return matchers 
 
 def match_patterns(patterns, files):
+    commit_safe = True
     for f in files:
         for p in patterns:
             if p['matcher'](f):
-                print '\033[91m' + "[ERROR] Unable to complete git commit." + '\033[0m' 
+                if commit_safe:
+                    print '\033[91m' + "[ERROR] Unable to complete git commit." + '\033[0m'
+                commit_safe = False
                 print "%s: %s" % (f, p['caption'])
                 if p['description']:
                     print p['description']
-                exit(1)
+    if not commit_safe:
+        exit(1)
 
 
 cmd='git diff --name-only --cached'


### PR DESCRIPTION
**When there are multiple unsafe files to be committed, print all of them instead just the first one.**

Before:
`mkdir test && cd test && git init && git init-safe-commit`
`touch credentials.xml`
`touch key.pem`
`touch secure.ppk`
`git add .`
`git commit`

Outputs:

```
[ERROR] Unable to complete git commit.
credentials.xml: Potential Jenkins credentials file
```

After:
`mkdir test && cd test && git init && git init-safe-commit`
`touch credentials.xml`
`touch key.pem`
`touch secure.ppk`
`git add .`
`git commit`

Outputs:

```
[ERROR] Unable to complete git commit.
credentials.xml: Potential Jenkins credentials file
key.pem: Potential cryptographic private key
secure.ppk: Potential cryptographic private key
```
