### PR TITLE
Added whitelisting feature and bug fix

### DIFF
--- a/git-deny-patterns.json
+++ b/git-deny-patterns.json
@@ -2,28 +2,28 @@
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A.*_rsa\\z",
+        "pattern": "\\A.*_rsa\\Z",
         "caption": "Private SSH key",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A.*_dsa\\z",
+        "pattern": "\\A.*_dsa\\Z",
         "caption": "Private SSH key",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A.*_ed25519\\z",
+        "pattern": "\\A.*_ed25519\\Z",
         "caption": "Private SSH key",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A.*_ecdsa\\z",
+        "pattern": "\\A.*_ecdsa\\Z",
         "caption": "Private SSH key",
         "description": null
     },
@@ -44,7 +44,7 @@
     {
         "part": "extension",
         "type": "regex",
-        "pattern": "\\Akey(pair)?\\z",
+        "pattern": "\\Akey(pair)?\\Z",
         "caption": "Potential cryptographic private key",
         "description": null
     },
@@ -86,84 +86,84 @@
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?(bash_|zsh_|z)?history\\z",
+        "pattern": "\\A\\.?(bash_|zsh_|z)?history\\Z",
         "caption": "Shell command history file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?mysql_history\\z",
+        "pattern": "\\A\\.?mysql_history\\Z",
         "caption": "MySQL client command history file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?psql_history\\z",
+        "pattern": "\\A\\.?psql_history\\Z",
         "caption": "PostgreSQL client command history file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?irb_history\\z",
+        "pattern": "\\A\\.?irb_history\\Z",
         "caption": "Ruby IRB console history file",
         "description": null
     },
     {
         "part": "path",
         "type": "regex",
-        "pattern": "\\.?purple\\/accounts\\.xml\\z",
+        "pattern": "\\.?purple\\/accounts\\.xml\\Z",
         "caption": "Pidgin chat client account configuration file",
         "description": null
     },
     {
         "part": "path",
         "type": "regex",
-        "pattern": "\\.?xchat2?\\/servlist_?\\.conf\\z",
+        "pattern": "\\.?xchat2?\\/servlist_?\\.conf\\Z",
         "caption": "Hexchat/XChat IRC client server list configuration file",
         "description": null
     },
     {
         "part": "path",
         "type": "regex",
-        "pattern": "\\.?irssi\\/config\\z",
+        "pattern": "\\.?irssi\\/config\\Z",
         "caption": "Irssi IRC client configuration file",
         "description": null
     },
     {
         "part": "path",
         "type": "regex",
-        "pattern": "\\.?recon-ng\\/keys\\.db\\z",
+        "pattern": "\\.?recon-ng\\/keys\\.db\\Z",
         "caption": "Recon-ng web reconnaissance framework API key database",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?dbeaver-data-sources.xml\\z",
+        "pattern": "\\A\\.?dbeaver-data-sources.xml\\Z",
         "caption": "DBeaver SQL database manager configuration file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?muttrc\\z",
+        "pattern": "\\A\\.?muttrc\\Z",
         "caption": "Mutt e-mail client configuration file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?s3cfg\\z",
+        "pattern": "\\A\\.?s3cfg\\Z",
         "caption": "S3cmd configuration file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?trc\\z",
+        "pattern": "\\A\\.?trc\\Z",
         "caption": "T command-line Twitter client configuration file",
         "description": null
     },
@@ -177,28 +177,28 @@
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?gitrobrc\\z",
+        "pattern": "\\A\\.?gitrobrc\\Z",
         "caption": "Well, this is awkward... Gitrob configuration file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?(bash|zsh)rc\\z",
+        "pattern": "\\A\\.?(bash|zsh)rc\\Z",
         "caption": "Shell configuration file",
         "description": "Shell configuration files might contain information such as server hostnames, passwords and API keys."
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?(bash_|zsh_)?profile\\z",
+        "pattern": "\\A\\.?(bash_|zsh_)?profile\\Z",
         "caption": "Shell profile configuration file",
         "description": "Shell configuration files might contain information such as server hostnames, passwords and API keys."
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?(bash_|zsh_)?aliases\\z",
+        "pattern": "\\A\\.?(bash_|zsh_)?aliases\\Z",
         "caption": "Shell command alias configuration file",
         "description": "Shell configuration files might contain information such as server hostnames, passwords and API keys."
     },
@@ -247,7 +247,7 @@
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A(.*)?config(\\.inc)?\\.php\\z",
+        "pattern": "\\A(.*)?config(\\.inc)?\\.php\\Z",
         "caption": "PHP configuration file",
         "description": "Might contain credentials and keys."
     },
@@ -275,7 +275,7 @@
     {
         "part": "extension",
         "type": "regex",
-        "pattern": "\\Akey(store|ring)\\z",
+        "pattern": "\\Akey(store|ring)\\Z",
         "caption": "GNOME Keyring database file",
         "description": null
     },
@@ -296,7 +296,7 @@
     {
         "part": "extension",
         "type": "regex",
-        "pattern": "\\Asql(dump)?\\z",
+        "pattern": "\\Asql(dump)?\\Z",
         "caption": "SQL dump file",
         "description": null
     },
@@ -352,14 +352,14 @@
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?htpasswd\\z",
+        "pattern": "\\A\\.?htpasswd\\Z",
         "caption": "Apache htpasswd file",
         "description": null
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A\\.?netrc\\z",
+        "pattern": "\\A\\.?netrc\\Z",
         "caption": "Configuration file for auto-login process",
         "description": "Might contain username and password."
     },
@@ -387,14 +387,14 @@
     {
         "part": "path",
         "type": "regex",
-        "pattern": "\\A\\.?gem/credentials\\z",
+        "pattern": "\\A\\.?gem/credentials\\Z",
         "caption": "Rubygems credentials file",
         "description": "Might contain API key for a rubygems.org account."
     },
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "\\A.*\\.pubxml(\\.user)?\\z",
+        "pattern": "\\A.*\\.pubxml(\\.user)?\\Z",
         "caption": "Potential MSBuild publish profile",
         "description": null
     },

--- a/safe-commit-hook.py
+++ b/safe-commit-hook.py
@@ -7,7 +7,7 @@ import re
 
 DEFAULT_PATTERNS = os.path.expanduser('~/.safe-commit-hook/git-deny-patterns.json')
 REPO_ROOT = os.getcwd()
-WHITELIST = os.path.join(REPO_ROOT, '.whitelist')
+WHITELIST = os.path.join(REPO_ROOT, '.git-safe-commit-ignore')
 
 
 def make_exact_matcher(str):

--- a/safe-commit-hook.py
+++ b/safe-commit-hook.py
@@ -5,10 +5,10 @@ import json
 import subprocess
 import re
 
-DEFAULT_PATTERNS = os.path.expanduser('~/.safe-commit-hook/git-deny-patterns.json')
-REPO_ROOT = os.getcwd()
-WHITELIST = os.path.join(REPO_ROOT, '.git-safe-commit-ignore')
-
+def get_repo_root():
+    output = subprocess.check_output('git rev-parse --show-toplevel', shell=True)
+    repo_root = output.split("\n")[0]
+    return os.path.join(repo_root)
 
 def make_exact_matcher(str):
     def m(target):
@@ -102,6 +102,10 @@ def match_patterns(patterns, files, whitelist=None):
     if not commit_safe:
         exit(1)
 
+
+DEFAULT_PATTERNS = os.path.expanduser('~/.safe-commit-hook/git-deny-patterns.json')
+REPO_ROOT = get_repo_root()
+WHITELIST = os.path.join(REPO_ROOT, '.git-safe-commit-ignore')
 
 cmd = 'git diff --name-only --cached'
 result = subprocess.check_output(cmd, shell=True)

--- a/safe-commit-hook.py
+++ b/safe-commit-hook.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import re
 
-DEFAULT_PATTERNS=os.path.expanduser('~/.safe-commit-hook/git-deny-patterns.json')
+DEFAULT_PATTERNS = os.path.expanduser('~/.safe-commit-hook/git-deny-patterns.json')
 REPO_ROOT = os.getcwd()
 WHITELIST = os.path.join(REPO_ROOT, '.whitelist')
 
@@ -13,26 +13,29 @@ WHITELIST = os.path.join(REPO_ROOT, '.whitelist')
 def make_exact_matcher(str):
     def m(target):
         return str == target
-    return m 
+    return m
+
 
 def make_regex_matcher(pattern):
     prog = re.compile(pattern)
     def m(target):
-        return prog.match(target) 
-    return m 
+        return prog.match(target)
+    return m
+
 
 def make_str_matcher(p):
     if p['type'] == 'regex':
         return make_regex_matcher(p['pattern'])
     elif p['type'] == 'match':
         return make_exact_matcher(p['pattern'])
-        
+
 
 def make_filename_matcher(p):
     def m(target_filename):
         t = os.path.basename(target_filename)
         return p['_match'](t)
     return m
+
 
 def make_extension_matcher(p):
     def m(target_filename):
@@ -41,10 +44,12 @@ def make_extension_matcher(p):
         return p['_match'](file_extension)
     return m
 
+
 def make_path_matcher(p):
     def m(target_filename):
         return p['_match'](target_filename)
     return m
+
 
 def make_matcher(p):
     p['_match'] = make_str_matcher(p)
@@ -56,16 +61,18 @@ def make_matcher(p):
     if p['part'] == 'path':
         return make_path_matcher(p)
 
+
 def read_patterns():
     matchers = []
-    with open(DEFAULT_PATTERNS) as data_file:    
+    with open(DEFAULT_PATTERNS) as data_file:
         data = json.load(data_file)
         for p in data:
             matcher = make_matcher(p)
             if matcher:
                 p['matcher'] = matcher
                 matchers.append(p)
-        return matchers 
+        return matchers
+
 
 def load_whitelist():
     ignore = []
@@ -75,6 +82,7 @@ def load_whitelist():
             path = os.path.join(REPO_ROOT, line)
             ignore.append(path)
     return ignore
+
 
 def match_patterns(patterns, files, whitelist=None):
     commit_safe = True
@@ -95,7 +103,7 @@ def match_patterns(patterns, files, whitelist=None):
         exit(1)
 
 
-cmd='git diff --name-only --cached'
+cmd = 'git diff --name-only --cached'
 result = subprocess.check_output(cmd, shell=True)
 files = result.split("\n")
 patterns = read_patterns()
@@ -105,4 +113,3 @@ if os.path.exists(WHITELIST):
     match_patterns(patterns, files, whitelist)
 else:
     match_patterns(patterns, files)
-


### PR DESCRIPTION
I added a project specific whitelisting feature. A user can define the files to be ignored by adding relative paths to a .git-safe-commit-ignore file (one path per line).

Few changes to Python source according to PEP8.

Changed \z to \Z in pattern file because \z does not work in Python
