### PR TITLE
Explicitly make global variables global

### DIFF
--- a/safe-commit-hook.py
+++ b/safe-commit-hook.py
@@ -103,6 +103,7 @@ def match_patterns(patterns, files, whitelist=None):
         exit(1)
 
 def main():
+    global DEFAULT_PATTERNS, REPO_ROOT, WHITELIST
     DEFAULT_PATTERNS = os.path.expanduser('~/.safe-commit-hook/git-deny-patterns.json')
     REPO_ROOT = get_repo_root()
     WHITELIST = os.path.join(REPO_ROOT, '.git-safe-commit-ignore')


### PR DESCRIPTION
Using Homebrew Python 2.7.10 on OS X, unless these variables are marked as global in `main` they become implicitly local since they are assigned. This prevents the hook from working because the implicitly local variables shadow their implicitly global counterparts in the rest of the code, and the global variables are never assigned.
